### PR TITLE
Fixes an error that occurs when the method returns an Optional Value.

### DIFF
--- a/lib/rbs_activesupport/method_searcher.rb
+++ b/lib/rbs_activesupport/method_searcher.rb
@@ -14,16 +14,24 @@ module RbsActivesupport
       delegate_to = lookup_method_types(delegate.namespace.to_type_name, delegate.to)
       return ["() -> untyped"] if delegate_to.any? { |t| t.type.return_type.is_a?(RBS::Types::Bases::Any) }
 
-      return_types = delegate_to
-                     .filter_map { |t| t.type.return_type.name } # steep:ignore NoMethod
-                     .uniq
-                     .flat_map { |t| lookup_method_types(t, delegate.method) }
-                     .map(&:to_s)
+      return_types = detect_return_type_names(delegate_to).uniq
+                                                          .flat_map { |t| lookup_method_types(t, delegate.method) }
+                                                          .map(&:to_s)
       return_types << "() -> untyped" if return_types.empty?
       return_types
     end
 
     private
+
+    def detect_return_type_names(delegate_to)
+      delegate_to.filter_map do |t|
+        if t.type.return_type.is_a?(RBS::Types::Optional)
+          t.type.return_type.type.name
+        else
+          t.type.return_type.name
+        end
+      end
+    end
 
     def lookup_method_types(type_name, method)
       instance = rbs_builder.build_instance(type_name)

--- a/sig/rbs_activesupport/method_searcher.rbs
+++ b/sig/rbs_activesupport/method_searcher.rbs
@@ -7,6 +7,7 @@ module RbsActivesupport
 
     private
 
+    def detect_return_type_names: (Array[RBS::MethodType] delegate_to) -> Array[RBS::TypeName]
     def lookup_method_types: (RBS::TypeName namespace, Symbol method) -> Array[RBS::MethodType]
   end
 end

--- a/spec/rbs_acrtivesupport/method_searcher_spec.rb
+++ b/spec/rbs_acrtivesupport/method_searcher_spec.rb
@@ -78,6 +78,20 @@ RSpec.describe RbsActivesupport::MethodSearcher do
 
           it { is_expected.to eq ["() -> ::Integer"] }
         end
+
+        context "When the delegated method that returns OptionalValue found" do
+          let(:signature) do
+            <<~RBS
+              class Foo
+                def bar: () -> String?
+              end
+            RBS
+          end
+          let(:delegate) { RbsActivesupport::Delegate.new(namespace, :size, { to: :bar }) }
+          let(:namespace) { RBS::Namespace.new(path: [:Foo], absolute: true) }
+
+          it { is_expected.to eq ["() -> ::Integer"] }
+        end
       end
     end
   end


### PR DESCRIPTION

I encountered the following error while adapting the rbs_activesupport gem to a Rails application, so I prepared a patch.

```
eval error: undefined method `name' for an instance of RBS::Types::Optional
  /rbs_activesupport/lib/rbs_activesupport/method_searcher.rb:1:in `block in method_types_for'
  /rbs_activesupport/lib/rbs_activesupport/method_searcher.rb:1:in `each'
  /rbs_activesupport/lib/rbs_activesupport/method_searcher.rb:1:in `filter_map'
  /rbs_activesupport/lib/rbs_activesupport/method_searcher.rb:1:in `method_types_for'
```

e.g. Rails application Model B has Optional Attribute "optional_x"

```
class A < ApplicationRecord
  has_one :b
  delegate :optional_x, to: b
end

class B < ApplicationRecord
  # optional_x is optional value
end
```

When trying to get .type.return_type from the delegate_to(RBS::MethodType) generated by MethodSearcher#lookup_method_types, RBS::Types::ClassInstance is expected for .type.return_type, but in the case of a method that returns an OptionaValue, RBS::Types::Optional is actually returned. In this case, an error occurs because RBS::Types::Optional does not have a name attribute.

I don't know whether RBS::Types::Optional needs a name attribute, but I noticed that I could get an attribute equivalent to a name attribute by following (RBS::Types::Optional).types, so I fixed it like this.