### PR TITLE
Fixes 'delegate :xxx, to: :class' Syntax (for steep 1.8.0 support)

### DIFF
--- a/lib/rbs_activesupport/method_searcher.rb
+++ b/lib/rbs_activesupport/method_searcher.rb
@@ -27,7 +27,7 @@ module RbsActivesupport
       delegate_to.filter_map do |t|
         if t.type.return_type.is_a?(RBS::Types::Optional)
           t.type.return_type.type.name
-        else
+        elsif t.type.return_type.respond_to?(:name)
           t.type.return_type.name
         end
       end

--- a/lib/rbs_activesupport/method_searcher.rb
+++ b/lib/rbs_activesupport/method_searcher.rb
@@ -14,16 +14,24 @@ module RbsActivesupport
       delegate_to = lookup_method_types(delegate.namespace.to_type_name, delegate.to)
       return ["() -> untyped"] if delegate_to.any? { |t| t.type.return_type.is_a?(RBS::Types::Bases::Any) }
 
-      return_types = delegate_to
-                     .filter_map { |t| t.type.return_type.name } # steep:ignore NoMethod
-                     .uniq
-                     .flat_map { |t| lookup_method_types(t, delegate.method) }
-                     .map(&:to_s)
+      return_types = detect_return_type_names(delegate_to).uniq
+                                                          .flat_map { |t| lookup_method_types(t, delegate.method) }
+                                                          .map(&:to_s)
       return_types << "() -> untyped" if return_types.empty?
       return_types
     end
 
     private
+
+    def detect_return_type_names(delegate_to)
+      delegate_to.filter_map do |t|
+        if t.type.return_type.is_a?(RBS::Types::Optional)
+          t.type.return_type.type.name
+        else
+          t.type.return_type.name
+        end
+      end
+    end
 
     def lookup_method_types(type_name, method)
       instance = rbs_builder.build_instance(type_name)

--- a/sig/rbs_activesupport/method_searcher.rbs
+++ b/sig/rbs_activesupport/method_searcher.rbs
@@ -7,6 +7,7 @@ module RbsActivesupport
 
     private
 
+    def detect_return_type_names: (Array[RBS::MethodType] delegate_to) -> Array[RBS::TypeName]
     def lookup_method_types: (RBS::TypeName namespace, Symbol method) -> Array[RBS::MethodType]
   end
 end

--- a/spec/rbs_acrtivesupport/generator_spec.rb
+++ b/spec/rbs_acrtivesupport/generator_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe RbsActivesupport::Generator do
           <<~RUBY
             class Foo
               delegate :size, :succ, to: :bar
+              delegate :piyo, to: :class
 
               def bar
                 "String"
@@ -103,6 +104,7 @@ RSpec.describe RbsActivesupport::Generator do
             class Foo < ::Object
               def size: () -> ::Integer
               def succ: () -> ::String
+              def piyo: () -> untyped
             end
           RBS
         end

--- a/spec/rbs_acrtivesupport/method_searcher_spec.rb
+++ b/spec/rbs_acrtivesupport/method_searcher_spec.rb
@@ -78,6 +78,20 @@ RSpec.describe RbsActivesupport::MethodSearcher do
 
           it { is_expected.to eq ["() -> ::Integer"] }
         end
+
+        context "When the delegated method that returns OptionalValue found" do
+          let(:signature) do
+            <<~RBS
+              class Foo
+                def bar: () -> String?
+              end
+            RBS
+          end
+          let(:delegate) { RbsActivesupport::Delegate.new(namespace, :size, { to: :bar }) }
+          let(:namespace) { RBS::Namespace.new(path: [:Foo], absolute: true) }
+
+          it { is_expected.to eq ["() -> ::Integer"] }
+        end
       end
     end
   end

--- a/spec/rbs_acrtivesupport/parser_spec.rb
+++ b/spec/rbs_acrtivesupport/parser_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe RbsActivesupport::Parser do
           class Foo
             delegate :foo, to: :bar
             delegate :baz, :qux, to: :quux, prefix: true
+            delegate :piyo, to: :class
           end
 
           class Bar
@@ -80,13 +81,16 @@ RSpec.describe RbsActivesupport::Parser do
         context, method_calls = parser.method_calls.to_a[0]
         expect(context.path).to eq [:Foo]
 
-        expect(method_calls.size).to eq 2
+        expect(method_calls.size).to eq 3
         expect(method_calls[0].name).to eq :delegate
         expect(method_calls[0].private?).to be_falsey
         expect(eval_node(method_calls[0].args)).to eq [:foo, { to: :bar }, nil]
         expect(method_calls[1].name).to eq :delegate
         expect(method_calls[1].private?).to be_falsey
         expect(eval_node(method_calls[1].args)).to eq [:baz, :qux, { to: :quux, prefix: true }, nil]
+        expect(method_calls[2].name).to eq :delegate
+        expect(method_calls[2].private?).to be_falsey
+        expect(eval_node(method_calls[2].args)).to eq [:piyo, { to: :class }, nil]
 
         context, method_calls = parser.method_calls.to_a[1]
         expect(context.path).to eq [:Bar]


### PR DESCRIPTION
Fixes 'delegate :xxx, to: :class' Syntax

When delegating to a class using `to: :class`, steep 1.8.0.pre.2 now throws an error.

RBS::Types::Function#return_type returns RBS::Types::Bases::Class in steep 1.8.0.pre.2, but an error occurs because RBS::Types::Bases::Class has no name.

e.g.

 Failure/Error: t.type.return_type.name

 NoMethodError:
   undefined method `name' for an instance of RBS::Types::Bases::Class

---

This branch is derived from[ #26](https://github.com/tk0miya/rbs_activesupport/pull/26). If you need to delete the 26 dependency, I'll recreate the branch from the main branch. Please let me know if you have any problems. (I created it as a derived branch because a conflict would occur if I created it from the main branch.)