### PR TITLE
Bump version to 1.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rbs_activesupport (1.7.0)
+    rbs_activesupport (1.7.1)
       activesupport
       railties
       rbs

--- a/lib/rbs_activesupport/version.rb
+++ b/lib/rbs_activesupport/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RbsActivesupport
-  VERSION = "1.7.0"
+  VERSION = "1.7.1"
 end


### PR DESCRIPTION
This release bumps the version of rbs_activesupport from 1.7.0 to 1.7.1.

**Changes:**
- Updated VERSION constant in `lib/rbs_activesupport/version.rb` to 1.7.1

This is a patch release.

https://claude.ai/code/session_01NxDPKtWue9UL69Pz9vSHse