### PR TITLE
ci: Add pull-requests read permission to dependabot-auto-label workflow

### DIFF
--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -1,6 +1,9 @@
 name: Add auto-merge label to Dependabot PRs
 on: pull_request
 
+permissions:
+  pull-requests: read
+
 jobs:
   add-auto-merge-label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Add explicit `pull-requests: read` permission to the dependabot-auto-label workflow.

## Background
On private repositories, the default GITHUB_TOKEN permissions can be more restrictive. The workflow needs explicit permissions to read pull request data.

This mirrors tk0miya/pem#54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)