### PR TITLE
ci: Pin action versions with exact-version comments

### DIFF
--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -17,7 +17,7 @@ jobs:
           permission-pull-requests: write
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Add auto-merge label

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           - '4.0'
 
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Set up Ruby

--- a/.github/workflows/rbs_collection.yml
+++ b/.github/workflows/rbs_collection.yml
@@ -21,7 +21,7 @@ jobs:
         permission-contents: write
         permission-pull-requests: write
         permission-issues: write
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Set up Ruby
@@ -32,7 +32,7 @@ jobs:
     - name: Update rbs collection
       run: bundle exec rbs collection update
     - name: Create a pull request
-      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
       with:
         add-paths: rbs_collection.lock.yaml
         commit-message: 'rbs: Update RBS collection'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Set up Ruby
@@ -30,4 +30,4 @@ jobs:
       - name: Install dependencies
         run: bundle install
       - name: Publish to RubyGems
-        uses: rubygems/release-gem@f0d7faff26625599a847d40d9fa28ace24c2aacc # v1
+        uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -14,7 +14,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Run actionlint
@@ -26,7 +26,7 @@ jobs:
   zizmor:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
## Problem

The `Workflow lint` job fails on zizmor's `ref-version-mismatch` audit (exit code 13).

Several actions are hash-pinned but commented with a **floating major tag** (e.g. `# v6`). When the action publishes a new release, that major tag moves to a newer commit than the pinned SHA, so the comment no longer matches the SHA and zizmor flags the mismatch. This recurs on every upstream release until the pin is bumped.

`actions/checkout` is the one currently failing: it is pinned to `de0fac2…` (**v6.0.2**) but commented `# v6`, which now resolves to v6.0.3.

## Fix

Normalize every hash-pinned action's comment to the **exact release** its SHA corresponds to, so the comment is stable across upstream releases. This mirrors the skill skeleton:

| action | pin |
|---|---|
| `actions/checkout` | `de0fac2…` `# v6.0.2` |
| `actions/create-github-app-token` | `bcd2ba4…` `# v3.2.0` |
| `actions/setup-node` | `48b55a0…` `# v6.4.0` |
| `dependabot/fetch-metadata` | `25dd0e3…` `# v3.1.0` |
| `peter-evans/create-pull-request` | `5f6978f…` `# v8.1.1` |
| `rubygems/release-gem` | `6317d8d…` `# v1.2.0` (SHA bumped from `f0d7faff…`) |

Only the pins present in this repo are changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
