### PR TITLE
Enable the rubocop-rbs_inline plugin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
 
 plugins:
   - rubocop-rake
+  - rubocop-rbs_inline
   - rubocop-rspec
 
 Layout/LeadingCommentSpace:
@@ -60,6 +61,15 @@ Style/HashSyntax:
 Style/OneClassPerFile:
   Exclude:
     - spec/**/*.rb
+
+Style/RbsInline/MissingTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
+
+Style/RbsInline/RedundantTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
+
+Style/RbsInline/RequireRbsInlineComment:
+  EnforcedStyle: never
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,12 +64,18 @@ Style/OneClassPerFile:
 
 Style/RbsInline/MissingTypeAnnotation:
   EnforcedStyle: doc_style_and_return_annotation
+  Exclude:
+    - "spec/**/*"
 
 Style/RbsInline/RedundantTypeAnnotation:
   EnforcedStyle: doc_style_and_return_annotation
 
 Style/RbsInline/RequireRbsInlineComment:
   EnforcedStyle: never
+
+Style/RbsInline/UntypedInstanceVariable:
+  Exclude:
+    - "spec/**/*"
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :development do
   gem "rspec", require: false
   gem "rubocop", "~> 1.88", require: false
   gem "rubocop-rake", require: false
+  gem "rubocop-rbs_inline", require: false
   gem "rubocop-rspec", require: false
   gem "ruby-lsp-rspec", require: false
   gem "steep", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,10 @@ GEM
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
+    rubocop-rbs_inline (1.5.5)
+      lint_roller (~> 1.1)
+      rbs-inline
+      rubocop (>= 1.72.1, < 2.0)
     rubocop-rspec (3.10.2)
       lint_roller (~> 1.1)
       regexp_parser (>= 2.0)
@@ -224,6 +228,7 @@ DEPENDENCIES
   rspec
   rubocop (~> 1.88)
   rubocop-rake
+  rubocop-rbs_inline
   rubocop-rspec
   ruby-lsp-rspec
   steep

--- a/lib/generators/rbs_activesupport/install_generator.rb
+++ b/lib/generators/rbs_activesupport/install_generator.rb
@@ -4,7 +4,7 @@ require "rails"
 
 module RbsActivesupport
   class InstallGenerator < Rails::Generators::Base
-    def create_raketask
+    def create_raketask #: void
       create_file "lib/tasks/rbs_activesupport.rake", <<~RUBY
         # frozen_string_literal: true
 

--- a/lib/rbs_activesupport/ast.rb
+++ b/lib/rbs_activesupport/ast.rb
@@ -22,7 +22,8 @@ module RbsActivesupport
       end
     end
 
-    def eval_node(node) # rubocop:disable Metrics/PerceivedComplexity
+    # @rbs node: untyped
+    def eval_node(node) #: untyped  # rubocop:disable Metrics/PerceivedComplexity
       case node
       when nil
         nil

--- a/lib/rbs_activesupport/parser.rb
+++ b/lib/rbs_activesupport/parser.rb
@@ -49,6 +49,7 @@ module RbsActivesupport
 
     # @rbs @in_included_block: bool
 
+    # @rbs parse_included_block: bool
     def initialize(parse_included_block: false) #: void
       super()
       @comment_parser = CommentParser.new

--- a/sig/generators/rbs_activesupport/install_generator.rbs
+++ b/sig/generators/rbs_activesupport/install_generator.rbs
@@ -2,6 +2,6 @@
 
 module RbsActivesupport
   class InstallGenerator < Rails::Generators::Base
-    def create_raketask: () -> untyped
+    def create_raketask: () -> void
   end
 end

--- a/sig/rbs_activesupport/parser.rbs
+++ b/sig/rbs_activesupport/parser.rbs
@@ -37,7 +37,7 @@ module RbsActivesupport
 
     @in_included_block: bool
 
-    def initialize: (?parse_included_block: untyped) -> void
+    def initialize: (?parse_included_block: bool) -> void
 
     # @rbs string: String
     def parse: (String string) -> void


### PR DESCRIPTION
## Summary

This gem uses rbs-inline annotations in `lib` but did not lint them. Adds the `rubocop-rbs_inline` RuboCop plugin (and its cop configuration) to match the `init-ruby-project` skeleton, so the inline type annotations are checked by `rake rubocop` / `rake ci`.

## Changes

- `Gemfile` / `Gemfile.lock`: add `rubocop-rbs_inline`
- `.rubocop.yml`
  - add `rubocop-rbs_inline` to `plugins`
  - add `Style/RbsInline/*` settings (matching the skeleton)

🤖 Generated with [Claude Code](https://claude.com/claude-code)