### PR TITLE
Introduce rubocop-numbered-params

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
   NewCops: enable
 
 plugins:
+  - rubocop-numbered-params
   - rubocop-rake
   - rubocop-rbs_inline
   - rubocop-rspec

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :development do
   gem "rbs-inline", require: false
   gem "rspec", require: false
   gem "rubocop", "~> 1.88", require: false
+  gem "rubocop-numbered-params", require: false
   gem "rubocop-rake", require: false
   gem "rubocop-rbs_inline", require: false
   gem "rubocop-rspec", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,9 @@ GEM
     rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
+    rubocop-numbered-params (1.0.0)
+      lint_roller (~> 1.0)
+      rubocop (>= 1.72.1)
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
@@ -227,6 +230,7 @@ DEPENDENCIES
   rbs_activesupport!
   rspec
   rubocop (~> 1.88)
+  rubocop-numbered-params
   rubocop-rake
   rubocop-rbs_inline
   rubocop-rspec

--- a/lib/rbs_activesupport/ast.rb
+++ b/lib/rbs_activesupport/ast.rb
@@ -30,7 +30,7 @@ module RbsActivesupport
       when Symbol, Hash, RBS::Namespace # Only for debug use
         node
       when Array
-        node.map { |e| eval_node(e) }
+        node.map { eval_node(_1) }
       when RubyVM::AbstractSyntaxTree::Node
         case node.type
         when :LIT, :STR, :SYM, :INTEGER, :FLOAT
@@ -38,7 +38,7 @@ module RbsActivesupport
         when :HASH
           children = node.children.first&.children
           if children
-            items = children.compact.map { |i| eval_node(i) }
+            items = children.compact.map { eval_node(_1) }
             Hash[*items]
           else
             {}
@@ -46,7 +46,7 @@ module RbsActivesupport
         when :ZLIST
           []
         when :LIST
-          node.children[...-1]&.map { |e| eval_node(e) }
+          node.children[...-1]&.map { eval_node(_1) }
         when :TRUE
           true
         when :FALSE

--- a/lib/rbs_activesupport/declaration_builder.rb
+++ b/lib/rbs_activesupport/declaration_builder.rb
@@ -24,8 +24,8 @@ module RbsActivesupport
     def build(namespace, method_calls, context = nil) #: [Array[String], Array[String]]
       built = build_method_calls(namespace, method_calls, context)
       public_decls, private_decls = built.partition(&:public?)
-      [public_decls.map { |decl| render(namespace, decl) },
-       private_decls.map { |decl| render(namespace, decl) }]
+      [public_decls.map { render(namespace, _1) },
+       private_decls.map { render(namespace, _1) }]
     end
 
     private

--- a/lib/rbs_activesupport/include.rb
+++ b/lib/rbs_activesupport/include.rb
@@ -64,7 +64,7 @@ module RbsActivesupport
       return [] unless parser
 
       method_calls = parser.method_calls[module_name] || []
-      method_calls.select { |call| call.name == :include && !call.included }
+      method_calls.select { _1.name == :include && !_1.included }
     end
 
     def method_calls_in_included_block #: Array[Parser::MethodCall]

--- a/lib/rbs_activesupport/method_searcher.rb
+++ b/lib/rbs_activesupport/method_searcher.rb
@@ -14,10 +14,10 @@ module RbsActivesupport
     # @rbs delegate: Delegate
     def method_types_for(delegate) #: Array[String]
       delegate_to = lookup_method_types(delegate.namespace.to_type_name, delegate.to)
-      return ["() -> untyped"] if delegate_to.any? { |t| t.type.return_type.is_a?(RBS::Types::Bases::Any) }
+      return ["() -> untyped"] if delegate_to.any? { _1.type.return_type.is_a?(RBS::Types::Bases::Any) }
 
       return_types = return_type_names_for(delegate_to).uniq
-                                                       .flat_map { |t| lookup_method_types(t, delegate.method) }
+                                                       .flat_map { lookup_method_types(_1, delegate.method) }
                                                        .map(&:to_s)
       return_types << "() -> untyped" if return_types.empty?
       return_types

--- a/lib/rbs_activesupport/types.rb
+++ b/lib/rbs_activesupport/types.rb
@@ -17,7 +17,7 @@ module RbsActivesupport
       when Array
         return "::Array[untyped]" if obj.empty?
 
-        items = obj.map { |e| guess_type(e) }.uniq
+        items = obj.map { guess_type(_1) }.uniq
         if items.include?("untyped")
           "::Array[untyped]"
         else
@@ -26,8 +26,8 @@ module RbsActivesupport
       when Hash
         return "::Hash[untyped, untyped]" if obj.empty?
 
-        keys = obj.keys.map { |e| guess_type(e) }.uniq
-        values = obj.values.map { |e| guess_type(e) }.uniq
+        keys = obj.keys.map { guess_type(_1) }.uniq
+        values = obj.values.map { guess_type(_1) }.uniq
         key_type = keys.include?("untyped") ? "untyped" : keys.join(" | ")
         value_type = values.include?("untyped") ? "untyped" : values.join(" | ")
         "::Hash[#{key_type}, #{value_type}]"

--- a/rbs_activesupport_delegate.gemspec
+++ b/rbs_activesupport_delegate.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
     end
   end
   spec.bindir = "exe"
-  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.executables = spec.files.grep(%r{\Aexe/}) { File.basename(_1) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport"

--- a/spec/rbs_activesupport/declaration_builder_spec.rb
+++ b/spec/rbs_activesupport/declaration_builder_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe RbsActivesupport::DeclarationBuilder do
 
     context "when the method_calls contains delegate calls" do
       let(:namespace) { RBS::Namespace.new(path: [:Foo], absolute: true) }
-      let(:method_calls) { method_calls_raw.map { |c| RbsActivesupport::Parser::MethodCall.new(*c) } }
+      let(:method_calls) { method_calls_raw.map { RbsActivesupport::Parser::MethodCall.new(*_1) } }
       let(:method_calls_raw) do
         [
           [:delegate, [:size, :to_s, { to: :bar }, nil], false],
@@ -59,7 +59,7 @@ RSpec.describe RbsActivesupport::DeclarationBuilder do
 
     context "when the method_calls contains class_attribute calls" do
       let(:namespace) { RBS::Namespace.new(path: [:Foo], absolute: true) }
-      let(:method_calls) { method_calls_raw.map { |c| RbsActivesupport::Parser::MethodCall.new(*c) } }
+      let(:method_calls) { method_calls_raw.map { RbsActivesupport::Parser::MethodCall.new(*_1) } }
 
       context "when no options are passed to the class_attribute call" do
         let(:method_calls_raw) { [[:class_attribute, [:foo, :bar, nil], false]] }
@@ -232,7 +232,7 @@ RSpec.describe RbsActivesupport::DeclarationBuilder do
 
     context "when the method_calls contains cattr_accessor/mattr_accessor calls" do
       let(:namespace) { RBS::Namespace.new(path: [:Foo], absolute: true) }
-      let(:method_calls) { method_calls_raw.map { |c| RbsActivesupport::Parser::MethodCall.new(*c) } }
+      let(:method_calls) { method_calls_raw.map { RbsActivesupport::Parser::MethodCall.new(*_1) } }
 
       context "when no options are given" do
         let(:method_calls_raw) do
@@ -415,7 +415,7 @@ RSpec.describe RbsActivesupport::DeclarationBuilder do
 
     context "when the method_calls contains cattr_reader/mattr_reader calls" do
       let(:namespace) { RBS::Namespace.new(path: [:Foo], absolute: true) }
-      let(:method_calls) { method_calls_raw.map { |c| RbsActivesupport::Parser::MethodCall.new(*c) } }
+      let(:method_calls) { method_calls_raw.map { RbsActivesupport::Parser::MethodCall.new(*_1) } }
 
       context "when no options are given" do
         let(:method_calls_raw) do
@@ -536,7 +536,7 @@ RSpec.describe RbsActivesupport::DeclarationBuilder do
 
     context "when the method_calls contains cattr_writer/mattr_writer calls" do
       let(:namespace) { RBS::Namespace.new(path: [:Foo], absolute: true) }
-      let(:method_calls) { method_calls_raw.map { |c| RbsActivesupport::Parser::MethodCall.new(*c) } }
+      let(:method_calls) { method_calls_raw.map { RbsActivesupport::Parser::MethodCall.new(*_1) } }
 
       context "when no options are given" do
         let(:method_calls_raw) do
@@ -666,7 +666,7 @@ RSpec.describe RbsActivesupport::DeclarationBuilder do
         end
 
         let(:namespace) { RBS::Namespace.new(path: [:Foo], absolute: true) }
-        let(:method_calls) { method_calls_raw.map { |c| RbsActivesupport::Parser::MethodCall.new(*c) } }
+        let(:method_calls) { method_calls_raw.map { RbsActivesupport::Parser::MethodCall.new(*_1) } }
         let(:method_calls_raw) do
           [
             [:include, [RBS::Namespace.parse("Bar"), nil], false],
@@ -684,7 +684,7 @@ RSpec.describe RbsActivesupport::DeclarationBuilder do
 
       context "when the included module has include call" do
         let(:namespace) { RBS::Namespace.new(path: [:Foo], absolute: true) }
-        let(:method_calls) { method_calls_raw.map { |c| RbsActivesupport::Parser::MethodCall.new(*c) } }
+        let(:method_calls) { method_calls_raw.map { RbsActivesupport::Parser::MethodCall.new(*_1) } }
         let(:method_calls_raw) do
           [
             [:include, [RBS::Namespace.parse("NestedIncludeModule"), nil], false]
@@ -702,7 +702,7 @@ RSpec.describe RbsActivesupport::DeclarationBuilder do
       context "when the included module has 'included' block" do
         context "when the included block contains class_attribute call" do
           let(:namespace) { RBS::Namespace.new(path: [:Foo], absolute: true) }
-          let(:method_calls) { method_calls_raw.map { |c| RbsActivesupport::Parser::MethodCall.new(*c) } }
+          let(:method_calls) { method_calls_raw.map { RbsActivesupport::Parser::MethodCall.new(*_1) } }
           let(:method_calls_raw) do
             [
               [:include, [RBS::Namespace.parse("IncludedClassAttributesModule"), nil], false]
@@ -726,7 +726,7 @@ RSpec.describe RbsActivesupport::DeclarationBuilder do
 
         context "when the included block contains delegate call" do
           let(:namespace) { RBS::Namespace.new(path: [:Foo], absolute: true) }
-          let(:method_calls) { method_calls_raw.map { |c| RbsActivesupport::Parser::MethodCall.new(*c) } }
+          let(:method_calls) { method_calls_raw.map { RbsActivesupport::Parser::MethodCall.new(*_1) } }
           let(:method_calls_raw) do
             [
               [:delegate, [:size, :to_s, { to: :bar }, nil], false]
@@ -746,7 +746,7 @@ RSpec.describe RbsActivesupport::DeclarationBuilder do
 
         context "when the included block contains include call" do
           let(:namespace) { RBS::Namespace.new(path: [:Foo], absolute: true) }
-          let(:method_calls) { method_calls_raw.map { |c| RbsActivesupport::Parser::MethodCall.new(*c) } }
+          let(:method_calls) { method_calls_raw.map { RbsActivesupport::Parser::MethodCall.new(*_1) } }
           let(:method_calls_raw) do
             [
               [:include, [RBS::Namespace.parse("IncludedIncludeModule"), nil], false]
@@ -767,7 +767,7 @@ RSpec.describe RbsActivesupport::DeclarationBuilder do
 
       context "when the same module was included twice" do
         let(:namespace) { RBS::Namespace.new(path: [:Foo], absolute: true) }
-        let(:method_calls) { method_calls_raw.map { |c| RbsActivesupport::Parser::MethodCall.new(*c) } }
+        let(:method_calls) { method_calls_raw.map { RbsActivesupport::Parser::MethodCall.new(*_1) } }
         let(:method_calls_raw) do
           [
             [:include, [RBS::Namespace.parse("IncludedIncludeModule"), nil], false],


### PR DESCRIPTION
Add the `rubocop-numbered-params` plugin to enforce a consistent style for numbered block parameters, matching the setup already used in other repositories.

- Add `rubocop-numbered-params` to the Gemfile and Gemfile.lock
- Register the plugin in `.rubocop.yml`
- Autocorrect existing offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)