### PR TITLE
Bump rubocop-rbs_inline to 1.6.0 and drop RbsInline Excludes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,18 +59,12 @@ RSpec/NestedGroups:
 # RbsInline
 Style/RbsInline/MissingTypeAnnotation:
   EnforcedStyle: doc_style_and_return_annotation
-  Exclude:
-    - "spec/**/*"
 
 Style/RbsInline/RedundantTypeAnnotation:
   EnforcedStyle: doc_style_and_return_annotation
 
 Style/RbsInline/RequireRbsInlineComment:
   EnforcedStyle: never
-
-Style/RbsInline/UntypedInstanceVariable:
-  Exclude:
-    - "spec/**/*"
 
 # Style
 Style/AccessorGrouping:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,7 +172,7 @@ GEM
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
-    rubocop-rbs_inline (1.5.5)
+    rubocop-rbs_inline (1.6.0)
       lint_roller (~> 1.1)
       rbs-inline
       rubocop (>= 1.72.1, < 2.0)


### PR DESCRIPTION
## Summary

`rubocop-rbs_inline` 1.6.0 no longer reports the spec files that
`Style/RbsInline/MissingTypeAnnotation` and
`Style/RbsInline/UntypedInstanceVariable` used to flag, so the `spec/**/*`
Excludes are no longer necessary.

## Changes

- `Gemfile.lock`: `rubocop-rbs_inline` 1.5.5 → 1.6.0
- `.rubocop.yml`: remove the `Style/RbsInline/MissingTypeAnnotation` Exclude
  and the `Style/RbsInline/UntypedInstanceVariable` override

The `cooldown: 7` source option is unchanged (it was only relaxed
temporarily to pull the freshly released 1.6.0 into the lockfile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)